### PR TITLE
Prevent multiple connections for an account #10

### DIFF
--- a/Source/Constructors/SG_Client.cpp
+++ b/Source/Constructors/SG_Client.cpp
@@ -7,7 +7,7 @@
 
 SG_Client::SG_Client()
 {
-	strChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	strChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1023456789";
 	playerid = 0;
 	charcreated = 0;
 	chartype = 0;

--- a/Source/Constructors/SG_Client.cpp
+++ b/Source/Constructors/SG_Client.cpp
@@ -7,7 +7,7 @@
 
 SG_Client::SG_Client()
 {
-	strChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1023456789";
+	strChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	playerid = 0;
 	charcreated = 0;
 	chartype = 0;

--- a/Source/Networking/MMO/SG_MmoServer.cpp
+++ b/Source/Networking/MMO/SG_MmoServer.cpp
@@ -16,13 +16,36 @@
 
 bool SG_MmoServer::OnClientConnected(const boost::shared_ptr<SG_ClientSession> pSession)
 {
-	SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] connected from: " + pSession->getSocket().remote_endpoint().address().to_string(), SG_Logger::kLogLevelMMO);
-	return true;
+
+	for (INT temp : idConnected)
+	{
+		if(temp == pSession->m_Player->playerid)
+		{
+			// User already connected
+			SG_Logger::instance().log("User already connected. Denying connection.", SG_Logger::kLogLevelMMO);
+			pSession->DisconnectClient();
+			return false;
+		}
+		else
+		{
+			// Connect player
+			SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] connected from: " + pSession->getSocket().remote_endpoint().address().to_string(), SG_Logger::kLogLevelMMO);
+			idConnected.push_back(pSession->m_Player->playerid);
+			return true;
+		}
+	}
 }
 
 void SG_MmoServer::OnClientDisconnect(const boost::shared_ptr<SG_ClientSession> pSession)
 {
 	SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] disconnected!", SG_Logger::kLogLevelMMO);
+	for (int i = 0;i < idConnected.size();i++)
+	{
+		if(idConnected[i] == pSession->m_Player->playerid)
+		{
+			idConnected.erase(idConnected.begin()+i);
+		}
+	}
 }
 
 bool SG_MmoServer::OnPacketReceived(const boost::shared_ptr<SG_ClientSession> pSession, const TS_MESSAGE* packet)

--- a/Source/Networking/MMO/SG_MmoServer.cpp
+++ b/Source/Networking/MMO/SG_MmoServer.cpp
@@ -17,7 +17,7 @@
 bool SG_MmoServer::OnClientConnected(const boost::shared_ptr<SG_ClientSession> pSession)
 {
 
-	for (INT temp : idConnected)
+	for (int temp : idConnected)
 	{
 		if(temp == pSession->m_Player->playerid)
 		{

--- a/Source/Networking/MMO/SG_MmoServer.cpp
+++ b/Source/Networking/MMO/SG_MmoServer.cpp
@@ -16,14 +16,10 @@
 
 bool SG_MmoServer::OnClientConnected(const boost::shared_ptr<SG_ClientSession> pSession)
 {
-
-	for (int temp : idConnected)
-	{
-			// Connect player
-			SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] connected from: " + pSession->getSocket().remote_endpoint().address().to_string(), SG_Logger::kLogLevelMMO);
-			//idConnected.push_back(pSession->m_Player->playerid);
-			return true;
-	}
+		// Connect player
+		SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] connected from: " + pSession->getSocket().remote_endpoint().address().to_string(), SG_Logger::kLogLevelMMO);
+		//idConnected.push_back(pSession->m_Player->playerid);
+		return true;
 }
 
 // TODO : WHY IS THIS THING PROC'D 2 TIMES WHEN DC ?? (the second is more or less 30s / 1min later)
@@ -36,12 +32,12 @@ void SG_MmoServer::OnClientDisconnect(const boost::shared_ptr<SG_ClientSession> 
 		{
 			if (nbConnected[i] == 2)
 			{
-				//std::cout << "remove first connection" << std::endl;
+				// std::cout << "remove first connection" << std::endl;
 				nbConnected[i] = 1;
 			}
 			else
 			{
-				std::cout << "remove second connection" << std::endl;
+				// std::cout << "remove second connection" << std::endl;
 				idConnected.erase(idConnected.begin() + i);
 				nbConnected.erase(nbConnected.begin() + i);
 			}

--- a/Source/Networking/MMO/SG_MmoServer.cpp
+++ b/Source/Networking/MMO/SG_MmoServer.cpp
@@ -16,13 +16,10 @@
 
 bool SG_MmoServer::OnClientConnected(const boost::shared_ptr<SG_ClientSession> pSession)
 {
-		// Connect player
 		SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] connected from: " + pSession->getSocket().remote_endpoint().address().to_string(), SG_Logger::kLogLevelMMO);
-		//idConnected.push_back(pSession->m_Player->playerid);
 		return true;
 }
 
-// TODO : WHY IS THIS THING PROC'D 2 TIMES WHEN DC ?? (the second is more or less 30s / 1min later)
 void SG_MmoServer::OnClientDisconnect(const boost::shared_ptr<SG_ClientSession> pSession)
 {
 	SG_Logger::instance().log("[" + pSession->m_Player->SessionKey + "] disconnected!", SG_Logger::kLogLevelMMO);
@@ -32,12 +29,10 @@ void SG_MmoServer::OnClientDisconnect(const boost::shared_ptr<SG_ClientSession> 
 		{
 			if (nbConnected[i] == 2)
 			{
-				// std::cout << "remove first connection" << std::endl;
 				nbConnected[i] = 1;
 			}
 			else
 			{
-				// std::cout << "remove second connection" << std::endl;
 				idConnected.erase(idConnected.begin() + i);
 				nbConnected.erase(nbConnected.begin() + i);
 			}

--- a/Source/Networking/MMO/SG_MmoServer.h
+++ b/Source/Networking/MMO/SG_MmoServer.h
@@ -5,8 +5,11 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include "Networking/General/SG_ServerBase.h"
 #include "Networking/General/SG_ClientSession.h"
+
 class SG_MmoServer : public SG_ServerBase
 {
+public:
+	std::vector<int> idConnected;
 
 private:
 	bool OnClientConnected(const boost::shared_ptr<SG_ClientSession> Session);

--- a/Source/Networking/MMO/SG_MmoServer.h
+++ b/Source/Networking/MMO/SG_MmoServer.h
@@ -9,7 +9,8 @@
 class SG_MmoServer : public SG_ServerBase
 {
 public:
-	std::vector<int> idConnected;
+	std::vector<int> idConnected; // Array with connected account IDs
+	std::vector<int> nbConnected; // Array needed to store "how many DC has been proc'd" -> 2 DC when user logs out.
 
 private:
 	bool OnClientConnected(const boost::shared_ptr<SG_ClientSession> Session);


### PR DESCRIPTION
#10 

A second "disconnect" is triggered 30-60 seconds after the logout, so user wont be able to reconnect within this time after he left the game.
